### PR TITLE
Add OpenVoice UI script

### DIFF
--- a/openvoice_ui.py
+++ b/openvoice_ui.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import tkinter as tk
+
+
+def init_gui():
+    """Initialize the GUI for OpenVoice."""
+    root = tk.Tk()
+    root.title("OpenVoice")
+    # Additional GUI setup would go here
+    return root
+
+
+if __name__ == "__main__":
+    root = init_gui()
+    root.mainloop()


### PR DESCRIPTION
## Summary
- add `openvoice_ui.py` with a Tkinter example
- ensure the script starts with a shebang
- wrap GUI execution in an `if __name__ == "__main__"` block

## Testing
- `python3 -m py_compile openvoice_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_687494e91acc83258fb0dcb12659803e