### PR TITLE
Fix UI installer path and indent

### DIFF
--- a/openvoice_ui.py
+++ b/openvoice_ui.py
@@ -49,7 +49,7 @@ def run_process(cmd_list):
 # -----------------------------------------------------------------------------
 
 def run_installer():
-    cmd = [sys.executable, "openvoice_installer.py", "--dir", install_dir_var.get()]
+    cmd = [sys.executable, "install_openvoice_full.py", "--dir", install_dir_var.get()]
     run_process(cmd)
 
 
@@ -262,7 +262,7 @@ tk.Button(top, text="Generate Full Audio", command=generate_audio).grid(row=5, c
 # column weights for nicer resizing -------------------------------------------
 
 top.columnconfigure(1, weight=1)
-	top.columnconfigure(3, weight=1)
+top.columnconfigure(3, weight=1)
 
 # -----------------------------------------------------------------------------
 # Scroll‑back log


### PR DESCRIPTION
## Summary
- run installer via `install_openvoice_full.py`
- fix column weight indentation in the UI

## Testing
- `python -m py_compile openvoice_ui.py`
- `python openvoice_ui.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6874d84bfcf88325ba9ceed413f3fd85