### PR TITLE
Automate dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Openvoice-pack
 
-Helper utilities for MyShell-AI OpenVoice V2. The installer script only writes the helper programs and does **not** automatically install Conda, Git, Python or PyTorch. Install those requirements manually before using the helpers.
+Helper utilities for MyShell-AI OpenVoice V2. The installer now downloads
+Miniconda if needed, creates an ``openvoice`` environment and installs Git,
+Python and PyTorch automatically.
 
-The installer also drops `long_synth.py`—a helper for long-form voice generation **and copies itself into the chosen directory so you can rerun it later**. After installation you can run:
+Use `install_openvoice_full.py` to copy the helper scripts into your desired directory. This is the same command run by the **Run Installer** button in `openvoice_ui.py`. The script also copies itself so you can rerun it later. After installation you can run:
 
 ```bash
 conda activate openvoice

--- a/openvoice_ui.py
+++ b/openvoice_ui.py
@@ -7,9 +7,11 @@ This launcher lets you:
   • Call the long‑form synthesiser (`long_synth.py`)
   • Extract timbre embeddings, preview a single sentence and generate full audio
 
-It expects the helper scripts (long_synth.py, extract_se.py, say.py …) to live
-next to this file. The installer puts copies of them in your chosen directory
-and also copies itself so you can re‑install later.
+It expects the helper scripts (``long_synth.py``, ``extract_se.py``,
+``say.py`` …) to live next to this file. The **Run Installer** button now runs
+``install_openvoice_full.py`` which installs Conda if needed, creates the
+required environment and copies the helpers into the directory you choose so you
+can re-run them later.
 """
 import tkinter as tk
 from tkinter import filedialog, scrolledtext, simpledialog
@@ -49,7 +51,7 @@ def run_process(cmd_list):
 # -----------------------------------------------------------------------------
 
 def run_installer():
-    cmd = [sys.executable, "openvoice_installer.py", "--dir", install_dir_var.get()]
+    cmd = [sys.executable, "install_openvoice_full.py", "--dir", install_dir_var.get()]
     run_process(cmd)
 
 
@@ -262,7 +264,7 @@ tk.Button(top, text="Generate Full Audio", command=generate_audio).grid(row=5, c
 # column weights for nicer resizing -------------------------------------------
 
 top.columnconfigure(1, weight=1)
-	top.columnconfigure(3, weight=1)
+top.columnconfigure(3, weight=1)
 
 # -----------------------------------------------------------------------------
 # Scroll‑back log


### PR DESCRIPTION
## Summary
- installer sets up Conda and required packages
- update docs to reflect automatic setup

## Testing
- `python -m py_compile openvoice_ui.py install_openvoice_full.py`
- `timeout 1 xvfb-run python openvoice_ui.py` *(exits via timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6874d84bfcf88325ba9ceed413f3fd85